### PR TITLE
feat(mock-fe): switch default OID4VC credential to SteuerberaterCredential

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ jobs:
       VITE_KEYCLOAK_URL: https://keycloak-demo.eudi-adorsys.com
       VITE_KEYCLOAK_REALM: oid4vc-vci
       VITE_KEYCLOAK_CLIENT_ID: oid4vc-demo-public
-      VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID: DatevCompanyCredential
+      VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID: SteuerberaterCredential
     runs-on: ubuntu-latest
 
     steps:

--- a/src/services/oid4vc.service.ts
+++ b/src/services/oid4vc.service.ts
@@ -12,11 +12,12 @@ interface CredentialOffer {
 }
 
 export const CredentialConfigurationId = {
-  KMA: 'KMACredential',
+  STEUERBERATER: 'SteuerberaterCredential',
 } as const;
 
 export const DEFAULT_CREDENTIAL_CONFIGURATION_ID =
-  import.meta.env.VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID || CredentialConfigurationId.KMA;
+  import.meta.env.VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID ||
+  CredentialConfigurationId.STEUERBERATER;
 
 const EndpointType = {
   KEYCLOAK_26_6_0: 'keycloak_26_6_0',


### PR DESCRIPTION
## Summary
- switch `keycloak-oid4vc-mock-fe` default credential configuration from KMA/Datev-oriented defaults to `SteuerberaterCredential`
- align GitHub Pages deployment workflow with the new default credential
- remove unused `KMA` entry from credential configuration constants to keep service config clean