### PR TITLE
Update mock-fe defaults to DatevCompanyCredential and new Keycloak demo URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VITE_KEYCLOAK_URL=https://keycloak-demo.solutions.adorsys.com
+VITE_KEYCLOAK_URL=https://your-keycloak-instance.com
 VITE_KEYCLOAK_REALM=your-realm
 VITE_KEYCLOAK_CLIENT_ID=your-client-id
 VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID=your-credential-config-id

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VITE_KEYCLOAK_URL=https://your-keycloak-instance.com
+VITE_KEYCLOAK_URL=https://keycloak-demo.solutions.adorsys.com
 VITE_KEYCLOAK_REALM=your-realm
 VITE_KEYCLOAK_CLIENT_ID=your-client-id
 VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID=your-credential-config-id

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rebuild:
     env:
-      VITE_KEYCLOAK_URL: https://keycloak-demo.eudi-adorsys.com
+      VITE_KEYCLOAK_URL: https://keycloak-demo.solutions.adorsys.com
       VITE_KEYCLOAK_REALM: oid4vc-vci
       VITE_KEYCLOAK_CLIENT_ID: oid4vc-demo-public
       VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID: SteuerberaterCredential

--- a/src/services/oid4vc.service.ts
+++ b/src/services/oid4vc.service.ts
@@ -12,12 +12,12 @@ interface CredentialOffer {
 }
 
 export const CredentialConfigurationId = {
-  STEUERBERATER: 'SteuerberaterCredential',
+  DATEV_COMPANY: 'DatevCompanyCredential',
 } as const;
 
 export const DEFAULT_CREDENTIAL_CONFIGURATION_ID =
   import.meta.env.VITE_OID4VC_DEFAULT_CREDENTIAL_CONFIGURATION_ID ||
-  CredentialConfigurationId.STEUERBERATER;
+  CredentialConfigurationId.DATEV_COMPANY;
 
 const EndpointType = {
   KEYCLOAK_26_6_0: 'keycloak_26_6_0',


### PR DESCRIPTION
Updated defaults to align with the current demo environment:

- Set default Keycloak URL to `https://keycloak-demo.solutions.adorsys.com/`
- Set default credential configuration to `DatevCompanyCredential`
- Removed dependency on `KMACredential` as default fallback in service logic
- Kept GitHub Pages workflow env defaults aligned with the same values
