### PR TITLE
refactor: improve credential status display

### DIFF
--- a/src/components/dashboard/CredentialsView.tsx
+++ b/src/components/dashboard/CredentialsView.tsx
@@ -194,7 +194,6 @@ function CredentialCard({
         }}
       >
         <DetailItem label="Issued" value={formatTimestamp(credential.issuedAt)} />
-        <DetailItem label="Revision" value={credential.revision || '-'} />
         <DetailItem
           label="Wallet client"
           value={credential.clientName || credential.clientId || '-'}
@@ -266,6 +265,7 @@ function DetailItem({ label, value }: { label: string; value: ReactNode }) {
 
 function StatusBadge({ status }: { status: CredentialStatus }) {
   const isRevoked = status === 'revoked';
+  const displayLabel = isRevoked ? 'Revoked' : 'Valid';
 
   return (
     <span
@@ -291,7 +291,7 @@ function StatusBadge({ status }: { status: CredentialStatus }) {
           backgroundColor: isRevoked ? '#842029' : '#0f5132',
         }}
       />
-      {status}
+      {displayLabel}
     </span>
   );
 }


### PR DESCRIPTION
## Changes
 
- Rename credential status "Active" to "Valid" for clearer UX
- Remove "Revision" field from the credential card UI
 
## Rationale
 
The "Revision" field is an internal Keycloak implementation detail used to track verifiable credential configuration changes. It's a randomly generated secure ID that gets incremented on every credential update. While useful for backend debugging, it provides no value to end users and clutters the interface.
 
## Testing
 
- The status badge now correctly displays "Valid" for active credentials and "Revoked" for revoked credentials

<img width="925" height="503" alt="image" src="https://github.com/user-attachments/assets/b0e74a0d-ef83-480e-92b9-8af3500e217a" />

Closes #27 